### PR TITLE
Add:ft_putchar_fd function to run with env command

### DIFF
--- a/builtins/ms_env.c
+++ b/builtins/ms_env.c
@@ -14,6 +14,7 @@
 
 int	ms_env(t_word *node)
 {
+	extern int	g_exit_status;
 	t_list	*env;
 
 	if (node)
@@ -22,9 +23,11 @@ int	ms_env(t_word *node)
 		env = NULL;
 	while (env)
 	{
-		printf("%s\n", (char *)env->content);
+		ft_putstr_fd(env->content, node->fd_out);
+		ft_putchar_fd('\n', node->fd_out);
 		env = env->next;
 	}
-	//settar a variável int de saída
+	ft_putchar_fd('\n', node->fd_out);
+	g_exit_status = 0;
 	return (0);
 }

--- a/builtins/ms_env.c
+++ b/builtins/ms_env.c
@@ -26,6 +26,5 @@ int	ms_env(t_word *node)
 		ft_putchar_fd('\n', node->fd_out);
 		env = env->next;
 	}
-	ft_putchar_fd('\n', node->fd_out);
 	return (0);
 }

--- a/builtins/ms_env.c
+++ b/builtins/ms_env.c
@@ -14,7 +14,6 @@
 
 int	ms_env(t_word *node)
 {
-	extern int	g_exit_status;
 	t_list	*env;
 
 	if (node)
@@ -28,6 +27,5 @@ int	ms_env(t_word *node)
 		env = env->next;
 	}
 	ft_putchar_fd('\n', node->fd_out);
-	g_exit_status = 0;
 	return (0);
 }

--- a/execution/main_executor.c
+++ b/execution/main_executor.c
@@ -96,8 +96,8 @@ int	main(void)
 	}
 	return (0);
 }
-rl_replace_line
-rl_on_new_line
+//rl_replace_line
+//rl_on_new_line
 
 
-iotcl pra jogar o \n no input com fake input (TIOCSTI).
+//iotcl pra jogar o \n no input com fake input (TIOCSTI).

--- a/execution/ms_executor.c
+++ b/execution/ms_executor.c
@@ -57,20 +57,8 @@ int	ms_executor(t_word **lst)
 
 void	ms_builtin_exec(t_word *node, uint16_t builtin)
 {
-	int			standardin;
-	int			standardout;
 	extern int	g_exit_status;
 
-	if (node->fd_in != STDIN_FILENO)
-	{
-		standardin = dup(STDIN_FILENO);
-		dup2(node->fd_in, STDIN_FILENO);
-	}
-	else if (node->fd_out != STDOUT_FILENO)
-	{
-		standardout = dup(STDOUT_FILENO);
-		dup2(node->fd_out, STDOUT_FILENO);
-	}
 	if (builtin == MS_ECHO)
 		g_exit_status = ms_echo(node);
 	else if (builtin == MS_CD)
@@ -79,24 +67,12 @@ void	ms_builtin_exec(t_word *node, uint16_t builtin)
 		g_exit_status = ms_pwd(node);
 	else if (builtin == MS_EXPORT)
 		g_exit_status = ms_export(node);
-	/*
+	else if (builtin == MS_ENV)
+		g_exit_status = ms_env(node);
 	else if (builtin == MS_UNSET)
-		exit_status = ms_unset(node);
+		g_exit_status = ms_unset(node);
 	else if (builtin == MS_EXIT)
-		exit_status = ms_exit(node);
-		*/
-	if (node->fd_in != STDIN_FILENO)
-	{
-		close(node->fd_in);
-		node->fd_in = STDIN_FILENO;
-		dup2(standardin, node->fd_in);
-	}
-	else if (node->fd_out != STDOUT_FILENO)
-	{
-		close(node->fd_out);
-		node->fd_out = STDOUT_FILENO;
-		dup2(standardout, node->fd_out);
-	}
+		g_exit_status = ms_exit(node);
 	return ;
 }
 
@@ -114,6 +90,8 @@ int	is_builtin(char *word)
 		return (MS_UNSET);
 	else if (ft_strncmp(word, "exit", 5) == 0)
 		return (MS_EXIT);
+	else if (ft_strncmp(word, "env", 4) == 0)
+		return (MS_ENV);
 	return (0);
 }
 

--- a/parser/ms_expand_env.c
+++ b/parser/ms_expand_env.c
@@ -80,7 +80,6 @@ int	ms_get_len_after_expansion(char *line, t_list *env)
 			must_expand ^= 1;
 		if (*line == '$' && must_expand && !ms_validate_env_name(line))
 		{
-			ms_exit_status_ret(line + 1);	
 			final_len += ms_get_expanded_env_len(line, env);
 			line += ms_get_env_name_len(line) + 1;
 		}


### PR DESCRIPTION
- Add_ft_putchar_fd function to run and work with env builtin command.

*Did some minor changes as delete a unused function on "ms_get_len_after_expand" function and comment some lines on executor's main file.