### PR TITLE
Fix(ret): now updates from left to right

### DIFF
--- a/execution/ms_executor.c
+++ b/execution/ms_executor.c
@@ -6,7 +6,7 @@
 /*   By: gsaiago <gsaiago@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/08 16:40:13 by gsaiago           #+#    #+#             */
-/*   Updated: 2023/04/25 18:00:58 by gsaiago          ###   ########.fr       */
+/*   Updated: 2023/04/28 16:01:00 by gsaiago          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,20 +46,18 @@ int	ms_executor(t_word **lst, t_list **env_lst)
 
 void	ms_builtin_exec(t_word *node, t_list **env_lst, uint16_t builtin)
 {
-	extern unsigned int	g_exit_status;
-
 	if (builtin == MS_ECHO)
-		g_exit_status = ms_echo(node);
+		node->ret = ms_echo(node);
 	else if (builtin == MS_CD)
-		g_exit_status = ms_cd(node);
+		node->ret = ms_cd(node);
 	else if (builtin == MS_PWD)
-		g_exit_status = ms_pwd(node);
+		node->ret = ms_pwd(node);
 	else if (builtin == MS_EXPORT)
-		g_exit_status = ms_export(node);
+		node->ret = ms_export(node);
 	else if (builtin == MS_ENV)
-		g_exit_status = ms_env(node);
+		node->ret = ms_env(node);
 	else if (builtin == MS_UNSET)
-		g_exit_status = ms_unset(node, env_lst);
+		node->ret = ms_unset(node, env_lst);
 	else if (builtin == MS_EXIT)
 		ms_exit(&node->head, &node->env_lst);
 	return ;

--- a/execution/ms_utils_exec.c
+++ b/execution/ms_utils_exec.c
@@ -6,7 +6,7 @@
 /*   By: gsaiago <gsaiago@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/20 15:33:15 by gsaiago           #+#    #+#             */
-/*   Updated: 2023/04/26 17:07:21 by gsaiago          ###   ########.fr       */
+/*   Updated: 2023/04/28 16:03:16 by gsaiago          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,15 +43,25 @@ char	**ms_get_cmd_mat_from_node(t_word *node)
 
 void	ms_wait_cmds(t_word *node)
 {
+	t_word				*aux;
 	extern unsigned int	g_exit_status;
 
 	if (!node)
 		return ;
+	aux = node;
 	while (node)
 	{
 		if (node->pid != 0)
-			waitpid(node->pid, (int *)&g_exit_status, 0);
+			waitpid(node->pid, &node->ret, 0);
 		node = node->next;
 	}
+	node = aux;
+	while (node)
+	{
+		if (node->ret >= 0)
+			g_exit_status = node->ret;
+		node = node->next;
+	}
+
 	return ;
 }

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: gsaiago <gsaiago@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/27 17:27:57 by gsaiago           #+#    #+#             */
-/*   Updated: 2023/04/25 20:19:41 by gsaiago          ###   ########.fr       */
+/*   Updated: 2023/04/28 15:58:59 by gsaiago          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,6 +105,7 @@ typedef struct s_word
 	unsigned int	flag;
 	int				fd_in;
 	int				fd_out;
+	int				ret;
 	pid_t			pid;
 	struct s_word	*head;
 	struct s_list	*env_lst;

--- a/parser/ms_utils_lst.c
+++ b/parser/ms_utils_lst.c
@@ -6,7 +6,7 @@
 /*   By: gsaiago <gsaiago@student.42.rio>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/27 18:50:10 by gsaiago           #+#    #+#             */
-/*   Updated: 2023/04/25 12:00:13 by gsaiago          ###   ########.fr       */
+/*   Updated: 2023/04/28 15:59:50 by gsaiago          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ t_word	*ms_lstnew(void *word)
 	new->pid = 0;
 	new->fd_in = 0;
 	new->fd_out = 1;
+	new->ret = -1;
 	new->next = NULL;
 	return (new);
 }


### PR DESCRIPTION
At the end of the day, the issue was about the global variable attribution and not the expansion itself. 
Because of the way that pipes work, the commands ran and stuck on previous pipes overwrote the global variable written by the builtin as soon as they were "unlocked".
The good ol' data race